### PR TITLE
WritableDialerContact expects Hash as data not Array

### DIFF
--- a/build/lib/purecloudplatformclientv2/models/writable_dialer_contact.rb
+++ b/build/lib/purecloudplatformclientv2/models/writable_dialer_contact.rb
@@ -96,7 +96,7 @@ module PureCloud
       
       if attributes.has_key?(:'data')
         
-        if (value = attributes[:'data']).is_a?(Array)
+        if (value = attributes[:'data']).is_a?(Hash)
           self.data = value
         end
         


### PR DESCRIPTION
Hey,

I think that WritableDialerContact is expecting data to be a Hash instead of Array.

Kind regards
Krzysztof Kotlarek